### PR TITLE
Add a link to download the SVG file

### DIFF
--- a/nautobot_floor_plan/templates/nautobot_floor_plan/inc/floorplan_svg.html
+++ b/nautobot_floor_plan/templates/nautobot_floor_plan/inc/floorplan_svg.html
@@ -3,6 +3,11 @@
 {% if floor_plan %}
     <h4>{{ floor_plan }} {% edit_button floor_plan %}</h4>
     Use scroll wheel to zoom in or out. Click and drag to scroll.
+    <div class="text-center text-small">
+        <a href="{% url 'plugins-api:nautobot_floor_plan-api:floorplan-svg' pk=floor_plan.pk %}" class="rack_elevation_save_svg_link" download="floor_plan_{{ floor_plan.location.name }}.svg">
+            <i class="mdi mdi-content-save-outline"></i> Save SVG
+        </a>
+    </div>
     {% comment %}
     Scale the SVG by default to match the page width, preserving its aspect-ratio.
     See https://css-tricks.com/scale-svg/ for more details.


### PR DESCRIPTION
Adds "Save SVG" link. Saves file as: `"floor_plan_{{ floor_plan.location.name }}.svg`

<img width="1027" alt="image" src="https://github.com/networktocode-llc/nautobot-plugin-floor-plan/assets/9260483/f922312b-4125-46ac-bb36-2a2bec1b7c9e">
