### PR TITLE
Shorten the docs project alias

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -19,7 +19,7 @@
     "model_class_name": "FloorPlan",
     "open_source_license": "Apache-2.0",
     "docs_base_url": "https://docs.nautobot.com",
-    "docs_app_url": "https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest",
+    "docs_app_url": "https://docs.nautobot.com/projects/floor-plan/en/latest",
     "_template": "./cookiecutter-ntc/nautobot-plugin"
   }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://raw.githubusercontent.com/nautobot/nautobot-plugin-floor-plan/develop/docs/images/icon-nautobot-floor-plan.png" class="logo" height="200px">
   <br>
   <a href="https://github.com/nautobot/nautobot-plugin-floor-plan/actions"><img src="https://github.com/nautobot/nautobot-plugin-floor-plan/actions/workflows/ci.yml/badge.svg?branch=main"></a>
-  <a href="https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest"><img src="https://readthedocs.org/projects/nautobot-plugin-floor-plan/badge/"></a>
+  <a href="https://docs.nautobot.com/projects/floor-plan/en/latest"><img src="https://readthedocs.org/projects/nautobot-plugin-floor-plan/badge/"></a>
   <a href="https://pypi.org/project/nautobot-floor-plan/"><img src="https://img.shields.io/pypi/v/nautobot-floor-plan"></a>
   <a href="https://pypi.org/project/nautobot-floor-plan/"><img src="https://img.shields.io/pypi/dm/nautobot-floor-plan"></a>
   <br>
@@ -25,26 +25,26 @@ This App aids in data center management by providing the ability to create a gri
 
 ![A new blank floor plan](https://raw.githubusercontent.com/nautobot/nautobot-plugin-floor-plan/develop/docs/images/floor-plan-empty.png)
 
-More screenshots can be found in the [Using the App](https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest/user/app_use_cases/) page in the documentation.
+More screenshots can be found in the [Using the App](https://docs.nautobot.com/projects/floor-plan/en/latest/user/app_use_cases/) page in the documentation.
 
 ## Documentation
 
 Full documentation for this App can be found over on the [Nautobot Docs](https://docs.nautobot.com) website:
 
-- [User Guide](https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest/user/app_overview/) - Overview, Using the App, Getting Started.
-- [Administrator Guide](https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest/admin/install/) - How to Install, Configure, Upgrade, or Uninstall the App.
-- [Developer Guide](https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest/dev/contributing/) - Extending the App, Code Reference, Contribution Guide.
-- [Release Notes / Changelog](https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest/admin/release_notes/).
-- [Frequently Asked Questions](https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest/user/faq/).
+- [User Guide](https://docs.nautobot.com/projects/floor-plan/en/latest/user/app_overview/) - Overview, Using the App, Getting Started.
+- [Administrator Guide](https://docs.nautobot.com/projects/floor-plan/en/latest/admin/install/) - How to Install, Configure, Upgrade, or Uninstall the App.
+- [Developer Guide](https://docs.nautobot.com/projects/floor-plan/en/latest/dev/contributing/) - Extending the App, Code Reference, Contribution Guide.
+- [Release Notes / Changelog](https://docs.nautobot.com/projects/floor-plan/en/latest/admin/release_notes/).
+- [Frequently Asked Questions](https://docs.nautobot.com/projects/floor-plan/en/latest/user/faq/).
 
 ### Contributing to the Documentation
 
 You can find all the Markdown source for the App documentation under the [`docs`](https://github.com/nautobot/nautobot-plugin-floor-plan/tree/develop/docs) folder in this repository. For simple edits, a Markdown capable editor is sufficient: clone the repository and edit away.
 
-If you need to view the fully-generated documentation site, you can build it with [MkDocs](https://www.mkdocs.org/). A container hosting the documentation can be started using the `invoke` commands (details in the [Development Environment Guide](https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest/dev/dev_environment/#docker-development-environment)) on [http://localhost:8001](http://localhost:8001). Using this container, as your changes to the documentation are saved, they will be automatically rebuilt and any pages currently being viewed will be reloaded in your browser.
+If you need to view the fully-generated documentation site, you can build it with [MkDocs](https://www.mkdocs.org/). A container hosting the documentation can be started using the `invoke` commands (details in the [Development Environment Guide](https://docs.nautobot.com/projects/floor-plan/en/latest/dev/dev_environment/#docker-development-environment)) on [http://localhost:8001](http://localhost:8001). Using this container, as your changes to the documentation are saved, they will be automatically rebuilt and any pages currently being viewed will be reloaded in your browser.
 
 Any PRs with fixes or improvements are very welcome!
 
 ## Questions
 
-For any questions or comments, please check the [FAQ](https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest/user/faq/) first. Feel free to also swing by the [Network to Code Slack](https://networktocode.slack.com/) (channel `#nautobot`), sign up [here](http://slack.networktocode.com/) if you don't have an account.
+For any questions or comments, please check the [FAQ](https://docs.nautobot.com/projects/floor-plan/en/latest/user/faq/) first. Feel free to also swing by the [Network to Code Slack](https://networktocode.slack.com/) (channel `#nautobot`), sign up [here](http://slack.networktocode.com/) if you don't have an account.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ dev_addr: "127.0.0.1:8001"
 edit_uri: "edit/develop/docs"
 site_dir: "nautobot_floor_plan/static/nautobot_floor_plan/docs"
 site_name: "Nautobot Floor Plan Documentation"
-site_url: "https://docs.nautobot.com/projects/nautobot-floor-plan/en/latest/"
+site_url: "https://docs.nautobot.com/projects/floor-plan/en/latest/"
 repo_url: "https://github.com/nautobot/nautobot-plugin-floor-plan"
 copyright: "Copyright &copy; The Authors"
 theme:


### PR DESCRIPTION
Changing the subproject alias for the docs URL to not include the word "nautobot" (reduce repetition and the shorter this is the better).