### PR TITLE
Fixing issue [158]

### DIFF
--- a/changes/158.fixed
+++ b/changes/158.fixed
@@ -1,1 +1,1 @@
-Fixed bug where x_origin was None when placing FloorPlanTiles, caused by fallback to default labels when custom labels didn't cover the full X or Y range.
+Fixed a bug when placing FloorPlanTiles when custom labels didn't cover the full X or Y range.

--- a/changes/158.fixed
+++ b/changes/158.fixed
@@ -1,0 +1,1 @@
+Fixed bug where x_origin was None when placing FloorPlanTiles, caused by fallback to default labels when custom labels didn't cover the full X or Y range.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Floor Plan! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #158 

## What's Changed

Changed Fallback labels when generating custom labels and the range wasn't large enough to cover the entire FloorPlan row to use Custom Axis labels of numbers instead of default number labels.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Unit, Integration Tests
