### PR TITLE
Adds XML unit-test helper task

### DIFF
--- a/changes/161.housekeeping
+++ b/changes/161.housekeeping
@@ -1,0 +1,1 @@
+Adds python coverage XML report for developers.

--- a/tasks.py
+++ b/tasks.py
@@ -15,6 +15,7 @@ limitations under the License.
 import os
 import re
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from time import sleep
 
@@ -857,6 +858,25 @@ def unittest_coverage(context):
     command = "coverage report --skip-covered --include 'nautobot_floor_plan/*' --omit *migrations*"
 
     run_command(context, command)
+
+
+@task(pre=[unittest])
+def unittest_xml_coverage(context):
+    """Produce an XML coverage report that can be ingested into other tools."""
+    produce_xml_cmd = "coverage xml --include 'nautobot_floor_plan/*'"
+    run_command(context, produce_xml_cmd)
+
+    # Since the container runs from a different working dir,
+    # We have to edit the XML to inject the current directory
+    # to play nice with tools outside of the container.
+    cur_dir = os.path.dirname(__file__)
+    cov_xml_path = os.path.join(cur_dir, "coverage.xml")
+
+    tree = ET.parse(cov_xml_path)  # noqa: S314
+    root = tree.getroot()
+
+    root.find(".//sources/source").text = cur_dir
+    tree.write(cov_xml_path, encoding="utf-8", xml_declaration=True)
 
 
 @task(


### PR DESCRIPTION
## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Added a helper task for invoke to generate an unit-test coverage XML. This is covered in upstream in the cookiecutter [here](https://github.com/nautobot/cookiecutter-nautobot-app/pull/212) but want to pull it in sooner while that one gets review.


## To Do

- [x] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))