### PR TITLE
Djhoward12 naaps 167 floorplan to rack elevation

### DIFF
--- a/changes/167.added
+++ b/changes/167.added
@@ -1,0 +1,1 @@
+Added links to grid labels to allow for quickly filtering rack elevation view.

--- a/docs/user/app_getting_started.md
+++ b/docs/user/app_getting_started.md
@@ -99,15 +99,15 @@ The **Custom Labels** tab provides options to configure a custom label range usi
 
   Both *numalpha* and *alphanumeric* label types support leading or non-leading zero formats.
 
-- **`label_type`**  
-  Specifies the type of label. Supported types include:  
-  - `numalpha (e.g., 02A, 05ZZ, 04AZ)`  
-  - `alphanumeric (e.g., A01, B02)`  
-  - `roman (e.g., I, II, III)`  
-  - `greek (e.g., α, β, γ)`  
-  - `hex (e.g., 0x0001, 0x000A, 0x000F)`  
-  - `binary (e.g., 0b0001, 0b1010, 0b0110)`  
-  - `letters (e.g., A, B, C)`  
+- **`label_type`**
+  Specifies the type of label. Supported types include:
+  - `numalpha (e.g., 02A, 05ZZ, 04AZ)`
+  - `alphanumeric (e.g., A01, B02)`
+  - `roman (e.g., I, II, III)`
+  - `greek (e.g., α, β, γ)`
+  - `hex (e.g., 0x0001, 0x000A, 0x000F)`
+  - `binary (e.g., 0b0001, 0b1010, 0b0110)`
+  - `letters (e.g., A, B, C)`
   - `numbers (e.g. 1, 2, 3)`
 
 There is a `Generate Preview` button that allows you to preview a range of labels that would be generated on the grid once the Floor Plan form has been saved.
@@ -237,9 +237,9 @@ Common Data:
 
 If you've defined a large floor plan or have a small display, you can use your mouse wheel to zoom in for a better view. While zoomed in, click and drag to pan around the grid.
 
-Additionally you can use the Enable Box Zoom/Switch to Pan Mode button to left click and drag a zoom box while Zoom is enabled, or pan in any direction when the Pan is enable. The Reset View button will reset the view back to the original rendered floor plan.
+Additionally you can use the Enable Box Zoom/Switch to Pan Mode button to left click and drag a zoom box while Zoom is enabled, or pan in any direction when Pan is enabled. The Reset View button will reset the view back to the original rendered floor plan.
 
-Clicking on a grid label for a given row will navigate to a Rack elevation view of racks filtered by the Floor Plan and the Racks in the chosen row.
+Clicking on a grid label for a given row (or column) will navigate to a Rack Elevation view of racks filtered by the Floor Plan and the Racks in the chosen row (or column).
 
 ![Floor plan zoom box button](../images/floorplan-click-drag-zoom.png)
 ![Floor plan zoomed in](../images/floorplan-zoomed.png)

--- a/docs/user/app_getting_started.md
+++ b/docs/user/app_getting_started.md
@@ -237,7 +237,9 @@ Common Data:
 
 If you've defined a large floor plan or have a small display, you can use your mouse wheel to zoom in for a better view. While zoomed in, click and drag to pan around the grid.
 
-Additional you can use the Enable Box Zoom/Switch to Pan Mode button to left click and drag a zoom box while Zoom is enabled, or pan in any direction when the Pan is enable. The Reset View button will reset the view back to the original rendered floor plan.
+Additionally you can use the Enable Box Zoom/Switch to Pan Mode button to left click and drag a zoom box while Zoom is enabled, or pan in any direction when the Pan is enable. The Reset View button will reset the view back to the original rendered floor plan.
+
+Clicking on a grid label for a given row will navigate to a Rack elevation view of racks filtered by the Floor Plan and the Racks in the chosen row.
 
 ![Floor plan zoom box button](../images/floorplan-click-drag-zoom.png)
 ![Floor plan zoomed in](../images/floorplan-zoomed.png)

--- a/docs/user/app_overview.md
+++ b/docs/user/app_overview.md
@@ -25,6 +25,7 @@ Included is a non-exhaustive list of capabilities beyond a standard MVC (model v
 - Provides visualization of Power Panels, and Racks being assigned to a Rack Group on a floor map.
 - Provides visualization of Tenant and Tenant Groups for Objects on a floor map.
 - Provides easy navigation from floor map to Object and subsequently device from Rack.
+- Provides easy navigation from floor map via grid labels to filter Rack elevations.
 - Provides easy navigation from Objects to Floor Plan. Objects will be centered and zoomed in for 5 seconds and highlighted on Floor Plan for 20 seconds.
 - Provides the ability to assign Objects to coordinates / tiles.
   - From the Floor Plan UI

--- a/docs/user/app_overview.md
+++ b/docs/user/app_overview.md
@@ -25,7 +25,7 @@ Included is a non-exhaustive list of capabilities beyond a standard MVC (model v
 - Provides visualization of Power Panels, and Racks being assigned to a Rack Group on a floor map.
 - Provides visualization of Tenant and Tenant Groups for Objects on a floor map.
 - Provides easy navigation from floor map to Object and subsequently device from Rack.
-- Provides easy navigation from floor map via grid labels to filter Rack elevations.
+- Provides easy navigation from floor map via grid labels to filter Rack Elevations.
 - Provides easy navigation from Objects to Floor Plan. Objects will be centered and zoomed in for 5 seconds and highlighted on Floor Plan for 20 seconds.
 - Provides the ability to assign Objects to coordinates / tiles.
   - From the Floor Plan UI

--- a/nautobot_floor_plan/filter_extensions.py
+++ b/nautobot_floor_plan/filter_extensions.py
@@ -1,9 +1,80 @@
 """Extensions to Nautobot core models' filtering functionality."""
 
+import logging
+
 import django_filters
 from nautobot.apps.filters import FilterExtension, RelatedMembershipBooleanFilter
 
 from nautobot_floor_plan import models
+from nautobot_floor_plan.utils.label_converters import LabelToPositionConverter, PositionToLabelConverter
+
+logger = logging.getLogger(__name__)
+
+
+class FloorPlanCoordinateFilter(django_filters.CharFilter):
+    """Custom filter that converts between human-readable labels and stored coordinates."""
+
+    def __init__(self, *, axis, **kwargs):
+        """Overwrite the constructor to set initial values."""
+        super().__init__(**kwargs)
+        self.axis = axis
+
+    def filter(self, qs, value):
+        """Convert label to position and filter."""
+        floor_plan_id = None
+        if not value:
+            return qs
+
+        try:
+            if hasattr(self, "parent") and self.parent and hasattr(self.parent, "data"):
+                floor_plan_id = self.parent.data.get("nautobot_floor_plan_floor_plan")
+            if not floor_plan_id:
+                return qs
+
+            floor_plan = models.FloorPlan.objects.get(pk=floor_plan_id)
+
+            # Check if custom labels are being used for this axis
+            if floor_plan.custom_labels.filter(axis=self.axis).exists():
+                # Use LabelToPositionConverter for custom labels
+                converter = LabelToPositionConverter(value, self.axis, floor_plan)
+                position, _ = converter.convert()
+            else:
+                # For default labels, use the value directly
+                position = value
+
+            return super().filter(qs, position)
+
+        except models.FloorPlan.DoesNotExist as e:
+            logger.error("Floor plan not found: %s", str(e))
+        except ValueError as e:
+            logger.error("Value error: %s", str(e))
+        return qs
+
+    def display_value(self, value):
+        """Convert stored numeric value to label for display."""
+        floor_plan_id = None
+        if not value:
+            return value
+
+        try:
+            if hasattr(self, "parent") and self.parent and hasattr(self.parent, "data"):
+                floor_plan_id = self.parent.data.get("nautobot_floor_plan_floor_plan")
+            if floor_plan_id and value is not None:
+                floor_plan = models.FloorPlan.objects.get(pk=floor_plan_id)
+
+                # Check if custom labels are being used for this axis
+                if floor_plan.custom_labels.filter(axis=self.axis).exists():
+                    # Use PositionToLabelConverter for custom labels
+                    converter = PositionToLabelConverter(int(value), self.axis, floor_plan)
+                    return converter.convert() or value
+                # For default labels, use the value directly
+                return value
+
+        except models.FloorPlan.DoesNotExist as e:
+            logger.error("Floor plan not found: %s", str(e))
+        except ValueError as e:
+            logger.error("Value error: %s", str(e))
+        return value
 
 
 class RackFilterExtension(FilterExtension):
@@ -21,7 +92,24 @@ class RackFilterExtension(FilterExtension):
             field_name="floor_plan_tile",
             label="Floor Plan Tile",
         ),
+        "nautobot_floor_plan_tile_x_origin": FloorPlanCoordinateFilter(
+            field_name="floor_plan_tile__x_origin",
+            label="Floor Plan Tile X Origin",
+            axis="X",
+        ),
+        "nautobot_floor_plan_tile_y_origin": FloorPlanCoordinateFilter(
+            field_name="floor_plan_tile__y_origin",
+            label="Floor Plan Tile Y Origin",
+            axis="Y",
+        ),
     }
+
+    def __init__(self, *args, **kwargs):
+        """Overwrite the constructor to set initial values."""
+        super().__init__(*args, **kwargs)
+        # Explicitly set 'parent' for all filters in filterset_fields
+        for _, filter_field in self.filterset_fields.items():
+            filter_field.parent = self
 
 
 class RackGroupFilterExtension(FilterExtension):

--- a/nautobot_floor_plan/static/nautobot_floor_plan/css/dark_svg.css
+++ b/nautobot_floor_plan/static/nautobot_floor_plan/css/dark_svg.css
@@ -135,6 +135,16 @@ rect.object-orientation {
     text-transform: capitalize;
 }
 
+.clickable-label {
+    cursor: pointer;
+    fill: #0066cc;
+}
+
+.clickable-label:hover {
+    fill: #0056b3;
+    text-decoration: underline;
+}
+
 /* spotlight, border, and arrow styles */
 .spotlight-effect {
     fill: rgba(255, 255, 0, 0.8);
@@ -149,7 +159,8 @@ rect.object-orientation {
 .indicator-arrow {
     fill: #ff3300;
 }
-/* Make sure all effect elements don't interfere with clicks */
+
+/* Highlight effects */
 .spotlight-effect,
 .highlight-border,
 .indicator-arrow {

--- a/nautobot_floor_plan/static/nautobot_floor_plan/css/svg.css
+++ b/nautobot_floor_plan/static/nautobot_floor_plan/css/svg.css
@@ -129,6 +129,16 @@ rect.object-orientation {
     text-transform: capitalize;
 }
 
+.clickable-label {
+    cursor: pointer;
+    fill: #0066cc;
+}
+
+.clickable-label:hover {
+    fill: #0056b3;
+    text-decoration: underline;
+}
+
 /* spotlight, border, and arrow styles */
 .spotlight-effect {
     fill: rgba(255, 255, 0, 0.8);
@@ -143,6 +153,7 @@ rect.object-orientation {
 .indicator-arrow {
     fill: #ff3300;
 }
+
 /* Highlight effects */
 .spotlight-effect,
 .highlight-border,

--- a/nautobot_floor_plan/svg.py
+++ b/nautobot_floor_plan/svg.py
@@ -219,7 +219,7 @@ class FloorPlanSVG:  # pylint: disable=too-many-instance-attributes
             filter_params = urlencode(
                 {
                     "nautobot_floor_plan_floor_plan": self.floor_plan.pk,
-                    "nautobot_floor_plan_tile_y_origin": label,
+                    "nautobot_floor_plan_tile_y_origin": label, # Pass the label instead of the numeric position
                 }
             )
             rack_url = f"{self.base_url}/dcim/rack-elevations/?{filter_params}"

--- a/nautobot_floor_plan/svg.py
+++ b/nautobot_floor_plan/svg.py
@@ -219,7 +219,7 @@ class FloorPlanSVG:  # pylint: disable=too-many-instance-attributes
             filter_params = urlencode(
                 {
                     "nautobot_floor_plan_floor_plan": self.floor_plan.pk,
-                    "nautobot_floor_plan_tile_y_origin": label, # Pass the label instead of the numeric position
+                    "nautobot_floor_plan_tile_y_origin": label,  # Pass the label instead of the numeric position
                 }
             )
             rack_url = f"{self.base_url}/dcim/rack-elevations/?{filter_params}"

--- a/nautobot_floor_plan/svg.py
+++ b/nautobot_floor_plan/svg.py
@@ -185,30 +185,55 @@ class FloorPlanSVG:  # pylint: disable=too-many-instance-attributes
         return x_labels, y_labels
 
     def _draw_axis_labels(self, drawing, x_labels, y_labels):
-        """Draw labels on the X and Y axes."""
+        """Draw labels on the X and Y axes with clickable links to rack elevations."""
+        # Create X-axis labels (column labels)
         for idx, label in enumerate(x_labels):
-            drawing.add(
+            # Create filter URL for racks in this row
+            filter_params = urlencode(
+                {
+                    "nautobot_floor_plan_floor_plan": self.floor_plan.pk,
+                    "nautobot_floor_plan_tile_x_origin": label,  # Pass the label instead of the numeric position
+                }
+            )
+            rack_url = f"{self.base_url}/dcim/rack-elevations/?{filter_params}"
+
+            # Create clickable link
+            link = drawing.add(drawing.a(href=rack_url, target="_top"))
+            link.add(
                 drawing.text(
                     label,
                     insert=(
                         (idx + 0.5) * self.GRID_SIZE_X + self.GRID_OFFSET,
                         self.BORDER_WIDTH + self.TEXT_LINE_HEIGHT / 2,
                     ),
-                    class_="grid-label",
+                    class_="grid-label clickable-label",
                 )
             )
+
+        # Create Y-axis labels (row labels)
         max_y_length = max(len(str(label)) for label in y_labels)
         y_label_text_offset = self._calculate_y_label_offset(max_y_length)
 
         for idx, label in enumerate(y_labels):
-            drawing.add(
+            # Create filter URL for racks in this row
+            filter_params = urlencode(
+                {
+                    "nautobot_floor_plan_floor_plan": self.floor_plan.pk,
+                    "nautobot_floor_plan_tile_y_origin": label,
+                }
+            )
+            rack_url = f"{self.base_url}/dcim/rack-elevations/?{filter_params}"
+
+            # Create clickable link
+            link = drawing.add(drawing.a(href=rack_url, target="_top"))
+            link.add(
                 drawing.text(
                     label,
                     insert=(
                         self.BORDER_WIDTH + self.TEXT_LINE_HEIGHT / 2 - y_label_text_offset,
                         (idx + 0.5) * self.GRID_SIZE_Y + self.GRID_OFFSET,
                     ),
-                    class_="grid-label",
+                    class_="grid-label clickable-label",
                 )
             )
 

--- a/nautobot_floor_plan/templates/nautobot_floor_plan/floorplan_create.html
+++ b/nautobot_floor_plan/templates/nautobot_floor_plan/floorplan_create.html
@@ -41,8 +41,6 @@
                 </div>
                 <!-- Custom Labels Tab -->
                 <div role="tabpanel" class="tab-pane {% if form.has_x_custom_labels or form.x_ranges.errors %}active{% endif %}" id="x-custom">
-                    
-
                     {{ form.x_ranges.management_form }}
                     <div class="table-responsive">
                         <table class="table table-bordered table-sm">
@@ -221,7 +219,7 @@
                     </button>
                     <button type="button" class="btn btn-info btn-sm mt-2" data-toggle="modal" data-target="#exampleModal">
                         <span class="mdi mdi-lightbulb" aria-hidden="true"></span> Examples
-                    </button>                    
+                    </button>
                     <div id="y-preview-section" class="mt-3">
                         <h5>Preview</h5>
                         <div id="y-preview"></div>
@@ -241,11 +239,11 @@
         function initializeRow(row) {
             const labelTypeSelect = row.querySelector('select[name*="label_type"]');
             const incrementLetterField = row.querySelector('input[name*="increment_letter"]');
-            
+
             if (labelTypeSelect && incrementLetterField) {
                 // Set initial state
                 updateCheckboxState(labelTypeSelect.value, incrementLetterField);
-                
+
                 // Add change listener
                 labelTypeSelect.addEventListener('change', function() {
                     updateCheckboxState(this.value, incrementLetterField);
@@ -255,10 +253,10 @@
 
         function updateCheckboxState(labelType, incrementLetterField) {
             if (!incrementLetterField) return;
-        
+
             // Store the previous checked state only if enabled
             const wasChecked = incrementLetterField.checked;
-        
+
             if (labelType === "numalpha" || labelType === "alphanumeric") {
                 // Enable and restore previous checked state
                 incrementLetterField.disabled = false;
@@ -273,7 +271,7 @@
                 incrementLetterField.checked = true;
             }
         }
-        
+
         // Initialize existing rows for both X and Y axes
         document.querySelectorAll('#x-ranges tr, #y-ranges tr').forEach(initializeRow);
 
@@ -285,21 +283,21 @@
                     const tbody = document.getElementById(`${axis}-ranges`);
                     const totalForms = document.getElementById(`id_${axis}_ranges-TOTAL_FORMS`);
                     const currentCount = parseInt(totalForms.value);
-                    
+
                     // Clone the empty form template
                     const emptyForm = document.getElementById(`${axis}-empty-form-template`);
                     if (emptyForm) {
                         const newRow = emptyForm.content.firstElementChild.cloneNode(true);
-                        
+
                         // Update form index
                         newRow.innerHTML = newRow.innerHTML.replaceAll(/__prefix__/g, currentCount.toString());
-                        
+
                         // Add the new row
                         tbody.appendChild(newRow);
-                        
+
                         // Initialize the new row
                         initializeRow(newRow);
-                        
+
                         // Update total forms count
                         totalForms.value = currentCount + 1;
                     }
@@ -316,21 +314,21 @@
             if (event.target.classList.contains("remove-range")) {
                 const row = event.target.closest("tr");
                 if (!row) return;
-                
+
                 const tbody = row.closest('tbody');
                 if (!tbody) return;
-                
+
                 // Instead of removing the row, mark it as deleted and hide it
                 const deleteInput = row.querySelector('input[name$="-DELETE"]');
                 if (deleteInput) {
                     deleteInput.value = 'on';  // Mark for deletion
                     row.style.display = 'none'; // Hide the row
                 }
-                
+
                 // Update form indices for visible rows
                 const formPrefix = tbody.id.includes('x-ranges') ? 'x_ranges' : 'y_ranges';
                 const visibleRows = Array.from(tbody.querySelectorAll('tr')).filter(r => r.style.display !== 'none');
-                
+
                 visibleRows.forEach((row, index) => {
                     row.querySelectorAll(`[name*="${formPrefix}-"]`).forEach(element => {
                         const newName = element.name.replace(
@@ -346,7 +344,7 @@
                         }
                     });
                 });
-                
+
                 // Update total form count (only count visible rows)
                 const totalForms = document.getElementById(`id_${formPrefix}-TOTAL_FORMS`);
                 if (totalForms) {
@@ -360,7 +358,7 @@
             const tbody = document.getElementById(`${axis}-ranges`);
             const previewSection = document.getElementById(`${axis}-preview`);
             previewSection.innerHTML = ""; // Clear previous preview
-    
+
             const rows = Array.from(tbody.querySelectorAll('tr')).filter(row => row.style.display !== 'none');
             rows.forEach(row => {
                 const startField = row.querySelector('input[name*="start"]');
@@ -368,7 +366,7 @@
                 const stepField = row.querySelector('input[name*="step"]');
                 const labelTypeField = row.querySelector('select[name*="label_type"]');
                 const incrementLetterField = row.querySelector('input[name*="increment_letter"]');
-    
+
                 if (startField && endField && stepField && labelTypeField) {
                     const startValue = startField.value;
                     const endValue = endField.value;
@@ -383,11 +381,11 @@
 
                     // Generate labels using the utility function
                     let labels = generateLabels(startValue, endValue, stepValue, labelType, incrementLetter);
-        
+
                     // Create a preview string
                     const previewString = `Labels: ${labels.join(', ')}`;
                     const truncatedPreview = previewString.length > 100 ? previewString.substring(0, 100) + '...' : previewString;
-    
+
                     // Append to the preview section
                     const previewItem = document.createElement('div');
                     previewItem.textContent = truncatedPreview;
@@ -404,11 +402,9 @@
         document.getElementById('generate-y-preview').addEventListener('click', function() {
             generatePreview('y');
         });
-    });    
+    }); 
 </script>
 
-    
-    
 {% include 'inc/extras_features_edit_form_fields.html' %}
 
 <!-- X Axis Empty Form Template -->

--- a/nautobot_floor_plan/templates/nautobot_floor_plan/floorplantile_create.html
+++ b/nautobot_floor_plan/templates/nautobot_floor_plan/floorplantile_create.html
@@ -17,9 +17,9 @@
 
     <div class="panel panel-default">
         <div class="panel-heading"><strong>Object Configuration</strong></div>
-        <div class="panel-body">  
+        <div class="panel-body">
             {% with power_feed_errors=form.power_feed.errors device_errors=form.device.errors power_panel_errors=form.power_panel.errors rack_errors=form.rack.errors %}
-            
+
             {# Add data attributes for JavaScript to use on a container div instead of body #}
             <div id="object-tabs-container"
                 data-rack-errors="{{ rack_errors|yesno:'true,false' }}"
@@ -50,22 +50,22 @@
                     <div role="tabpanel" class="tab-pane" id="rack">
                         {% render_field form.rack %}
                     </div>
-                
+
                     <div role="tabpanel" class="tab-pane" id="device">
                         {% render_field form.device %}
                     </div>
-                
+
                     <div role="tabpanel" class="tab-pane" id="power-panel">
                         {% render_field form.power_panel %}
                     </div>
-                
+
                     <div role="tabpanel" class="tab-pane" id="power-feed">
                         {% render_field form.power_feed %}
                     </div>
                 </div>
             </div>
             {% endwith %}
-            
+
             <!-- Object orientation field outside of tabs so it's always available -->
             {% render_field form.object_orientation %}
         </div>

--- a/nautobot_floor_plan/templates/nautobot_floor_plan/inc/floorplan_svg.html
+++ b/nautobot_floor_plan/templates/nautobot_floor_plan/inc/floorplan_svg.html
@@ -16,7 +16,8 @@
         Click and drag to scroll.
         <button id="toggle-zoom-mode" class="btn btn-sm btn-default">Enable Box Zoom</button>
         <button id="reset-zoom" class="btn btn-sm btn-secondary">Reset View</button><br>
-        Add a tile by clicking the plus symbol on the grid OR by using the "Add Tile" button.
+        Add a tile by clicking the plus symbol on the grid OR by using the "Add Tile" button.<br>
+        Click on a Row's Label to see the Elevation for all Racks in the row.
     </div>
 
     <div class="text-center text-small">

--- a/nautobot_floor_plan/tests/test_filters.py
+++ b/nautobot_floor_plan/tests/test_filters.py
@@ -271,7 +271,7 @@ class TestFloorPlanCoordinateFilter(TestCase):
         filter_instance.parent = MagicMock()
         filter_instance.parent.data = {"nautobot_floor_plan_floor_plan": self.floor_plan.pk}
 
-        # Apply filter with label "B" or "2" (depends on your label system)
+        # Apply filter with label "B"
         test_qs = models.FloorPlanTile.objects.all()
         filtered_qs = filter_instance.filter(test_qs, "B")
 

--- a/nautobot_floor_plan/tests/test_label_generator.py
+++ b/nautobot_floor_plan/tests/test_label_generator.py
@@ -3,7 +3,7 @@
 from nautobot.core.testing import TestCase
 
 from nautobot_floor_plan import models
-from nautobot_floor_plan.tests import fixtures
+from nautobot_floor_plan.tests import fixtures, utils
 from nautobot_floor_plan.utils.custom_validators import RangeValidator
 from nautobot_floor_plan.utils.label_generator import FloorPlanLabelGenerator
 
@@ -20,23 +20,10 @@ class TestNumericLabelGenerator(TestCase):
         self.floor_plan.validated_save()
         self.validator = RangeValidator(max_size=10)
 
-    def create_custom_labels(self, labels_config, axis="X"):
-        """Helper to create custom labels from config."""
-        for config in labels_config:
-            models.FloorPlanCustomAxisLabel.objects.create(
-                floor_plan=self.floor_plan,
-                axis=axis,
-                start_label=config["start"],
-                end_label=config["end"],
-                step=config["step"],
-                increment_letter=config["increment_letter"],
-                label_type=config["label_type"],
-            )
-
     def test_custom_number_ranges(self):
         """Test custom number ranges with basic incrementing."""
         config = [{"start": "1", "end": "5", "step": 1, "increment_letter": True, "label_type": "numbers"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["1", "2", "3", "4", "5"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -44,7 +31,7 @@ class TestNumericLabelGenerator(TestCase):
     def test_custom_number_ranges_with_leading_zeros(self):
         """Test custom number ranges with leading zeros."""
         config = [{"start": "01", "end": "05", "step": 1, "increment_letter": True, "label_type": "numbers"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["01", "02", "03", "04", "05"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -52,7 +39,7 @@ class TestNumericLabelGenerator(TestCase):
     def test_custom_number_ranges_negative_step(self):
         """Test custom number ranges with negative steps."""
         config = [{"start": "5", "end": "1", "step": -1, "increment_letter": True, "label_type": "numbers"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["5", "4", "3", "2", "1"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -60,7 +47,7 @@ class TestNumericLabelGenerator(TestCase):
     def test_custom_number_ranges_with_leading_zeros_negative_step(self):
         """Test custom number ranges with leading zeros and negative steps."""
         config = [{"start": "05", "end": "01", "step": -1, "increment_letter": False, "label_type": "numbers"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["05", "04", "03", "02", "01"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -71,7 +58,7 @@ class TestNumericLabelGenerator(TestCase):
             {"start": "01", "end": "03", "step": 1, "increment_letter": True, "label_type": "numbers"},
             {"start": "10", "end": "12", "step": 1, "increment_letter": True, "label_type": "numbers"},
         ]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 6)
         expected = ["01", "02", "03", "10", "11", "12"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -82,7 +69,7 @@ class TestNumericLabelGenerator(TestCase):
             {"start": "1", "end": "3", "step": 1, "increment_letter": True, "label_type": "numbers"},
             {"start": "04", "end": "06", "step": 1, "increment_letter": True, "label_type": "numbers"},
         ]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 6)
         expected = ["1", "2", "3", "04", "05", "06"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -90,7 +77,7 @@ class TestNumericLabelGenerator(TestCase):
     def test_custom_alphanumeric_ranges(self):
         """Test custom alphanumeric ranges with number incrementing."""
         config = [{"start": "A01", "end": "A05", "step": 1, "increment_letter": False, "label_type": "alphanumeric"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["A01", "A02", "A03", "A04", "A05"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -98,7 +85,7 @@ class TestNumericLabelGenerator(TestCase):
     def test_custom_alphanumeric_ranges_no_leading_zero(self):
         """Test custom alphanumeric ranges without leading zeros."""
         config = [{"start": "A1", "end": "A5", "step": 1, "increment_letter": False, "label_type": "alphanumeric"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["A1", "A2", "A3", "A4", "A5"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -106,7 +93,7 @@ class TestNumericLabelGenerator(TestCase):
     def test_custom_alphanumeric_ranges_increment_prefix(self):
         """Test custom alphanumeric ranges with prefix incrementing."""
         config = [{"start": "A01", "end": "E01", "step": 1, "increment_letter": True, "label_type": "alphanumeric"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["A01", "B01", "C01", "D01", "E01"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -114,7 +101,7 @@ class TestNumericLabelGenerator(TestCase):
     def test_custom_alphanumeric_ranges_increment_prefix_no_leading_zero(self):
         """Test custom alphanumeric ranges with prefix incrementing and no leading zeros."""
         config = [{"start": "A1", "end": "E1", "step": 1, "increment_letter": True, "label_type": "alphanumeric"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["A1", "B1", "C1", "D1", "E1"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -122,7 +109,7 @@ class TestNumericLabelGenerator(TestCase):
     def test_custom_alphanumeric_ranges_negative(self):
         """Test custom alphanumeric ranges with negative steps."""
         config = [{"start": "A05", "end": "A01", "step": -1, "increment_letter": False, "label_type": "alphanumeric"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["A05", "A04", "A03", "A02", "A01"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -130,7 +117,7 @@ class TestNumericLabelGenerator(TestCase):
     def test_custom_alphanumeric_ranges_negative_prefix(self):
         """Test custom alphanumeric ranges with negative steps and prefix incrementing."""
         config = [{"start": "E01", "end": "A01", "step": -1, "increment_letter": True, "label_type": "alphanumeric"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["E01", "D01", "C01", "B01", "A01"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -139,7 +126,7 @@ class TestNumericLabelGenerator(TestCase):
         """Test that default labels are generated when custom range is insufficient using numbers label."""
         # Create a custom label range that is smaller than the requested count
         config = [{"start": "1", "end": "3", "step": 1, "increment_letter": True, "label_type": "numbers"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
 
         # Request more labels than the custom range provides
         labels = self.floor_plan.generate_labels("X", 5)  # Request 5 labels
@@ -152,7 +139,7 @@ class TestNumericLabelGenerator(TestCase):
         """Test that default labels are generated when custom range is insufficient using numalpha label."""
         # create custom label with numalpha that is smaller than the requested count
         config = [{"start": "02A", "end": "02C", "step": 1, "increment_letter": True, "label_type": "numalpha"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
 
         # Request more labels than the custom range provides
         labels = self.floor_plan.generate_labels("X", 5)  # Request 5 labels
@@ -174,23 +161,10 @@ class TestLetterLabelGenerator(TestCase):
         self.floor_plan.validated_save()
         self.validator = RangeValidator(max_size=10)
 
-    def create_custom_labels(self, labels_config, axis="X"):
-        """Helper to create custom labels from config."""
-        for config in labels_config:
-            models.FloorPlanCustomAxisLabel.objects.create(
-                floor_plan=self.floor_plan,
-                axis=axis,
-                start_label=config["start"],
-                end_label=config["end"],
-                step=config["step"],
-                increment_letter=config["increment_letter"],
-                label_type=config["label_type"],
-            )
-
     def test_custom_letter_ranges(self):
         """Test custom letter ranges with different configurations."""
         config = [{"start": "C", "end": "Z", "step": 1, "increment_letter": True, "label_type": "letters"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 24)
         expected = [chr(65 + i) for i in range(2, 26)]  # C through Z
         self.assertEqual(labels[: len(expected)], expected)
@@ -198,7 +172,7 @@ class TestLetterLabelGenerator(TestCase):
     def test_custom_letter_ranges_negative_step(self):
         """Test custom letter ranges with negative steps."""
         config = [{"start": "E", "end": "A", "step": -1, "increment_letter": True, "label_type": "letters"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["E", "D", "C", "B", "A"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -209,7 +183,7 @@ class TestLetterLabelGenerator(TestCase):
             {"start": "A", "end": "C", "step": 1, "increment_letter": True, "label_type": "letters"},
             {"start": "X", "end": "Z", "step": 1, "increment_letter": True, "label_type": "letters"},
         ]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 6)
         expected = ["A", "B", "C", "X", "Y", "Z"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -217,7 +191,7 @@ class TestLetterLabelGenerator(TestCase):
     def test_custom_numalpha_ranges(self):
         """Test custom numalpha ranges with letter incrementing."""
         config = [{"start": "02A", "end": "02E", "step": 1, "increment_letter": True, "label_type": "numalpha"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["02A", "02B", "02C", "02D", "02E"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -225,7 +199,7 @@ class TestLetterLabelGenerator(TestCase):
     def test_custom_numalpha_ranges_no_leading_zero(self):
         """Test custom numalpha ranges without leading zeros."""
         config = [{"start": "2A", "end": "2E", "step": 1, "increment_letter": True, "label_type": "numalpha"}]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 5)
         expected = ["2A", "2B", "2C", "2D", "2E"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -236,7 +210,7 @@ class TestLetterLabelGenerator(TestCase):
             {"start": "01A", "end": "01C", "step": 1, "increment_letter": True, "label_type": "numalpha"},
             {"start": "02X", "end": "02Z", "step": 1, "increment_letter": True, "label_type": "numalpha"},
         ]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 6)
         expected = ["01A", "01B", "01C", "02X", "02Y", "02Z"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -247,7 +221,7 @@ class TestLetterLabelGenerator(TestCase):
             {"start": "02EE", "end": "02EA", "step": -1, "increment_letter": True, "label_type": "numalpha"},
             {"start": "02E", "end": "02A", "step": -1, "increment_letter": False, "label_type": "numalpha"},
         ]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 10)
         expected = ["02EE", "02ED", "02EC", "02EB", "02EA", "02E", "02D", "02C", "02B", "02A"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -258,7 +232,7 @@ class TestLetterLabelGenerator(TestCase):
             {"start": "02EE", "end": "02AA", "step": -1, "increment_letter": False, "label_type": "numalpha"},
             {"start": "02E", "end": "02A", "step": -1, "increment_letter": False, "label_type": "numalpha"},
         ]
-        self.create_custom_labels(config)
+        utils.create_custom_labels(self.floor_plan, config)
         labels = self.floor_plan.generate_labels("X", 10)
         expected = ["02EE", "02DD", "02CC", "02BB", "02AA", "02E", "02D", "02C", "02B", "02A"]
         self.assertEqual(labels[: len(expected)], expected)
@@ -274,20 +248,6 @@ class TestLabelRangeOrder(TestCase):
         self.status = data["status"]
         self.floor_plan = models.FloorPlan(location=self.floors[0], x_size=10, y_size=10)
         self.floor_plan.validated_save()
-
-    def create_custom_labels(self, labels_config, axis="X"):
-        """Helper to create custom labels from config."""
-        for config in labels_config:
-            models.FloorPlanCustomAxisLabel.objects.create(
-                floor_plan=self.floor_plan,
-                axis=axis,
-                start_label=config["start"],
-                end_label=config["end"],
-                step=config["step"],
-                increment_last_letter=config["increment_last_letter"],
-                label_type=config["label_type"],
-                order=config["order"],
-            )
 
 
 def test_custom_range_order_consistency(self):
@@ -311,7 +271,7 @@ def test_custom_range_order_consistency(self):
             "order": 2,
         },
     ]
-    self.create_custom_labels(config)
+    utils.create_custom_labels(self.floor_plan, config)
 
     # Verify order in database
     ranges = self.floor_plan.get_custom_ranges("X")
@@ -339,7 +299,7 @@ def test_custom_range_order_mixed_types(self):
         {"start": "01", "end": "05", "step": 1, "increment_last_letter": True, "label_type": "numbers", "order": 2},
         {"start": "02A", "end": "02E", "step": 1, "increment_last_letter": True, "label_type": "numalpha", "order": 3},
     ]
-    self.create_custom_labels(config)
+    utils.create_custom_labels(self.floor_plan, config)
 
     # Verify order in database
     ranges = self.floor_plan.get_custom_ranges("X")

--- a/nautobot_floor_plan/tests/utils.py
+++ b/nautobot_floor_plan/tests/utils.py
@@ -2,7 +2,24 @@
 
 from importlib.metadata import version as get_version
 
+from nautobot_floor_plan import models
+
 
 def is_nautobot_version_less_than(required_version: str) -> bool:
     """Check if the current Nautobot version is less than the required version."""
     return get_version("nautobot") < required_version
+
+
+def create_custom_labels(floor_plan, labels_config, axis="X"):
+    """Helper to create custom labels from config."""
+
+    for config in labels_config:
+        models.FloorPlanCustomAxisLabel.objects.create(
+            floor_plan=floor_plan,
+            axis=axis,
+            start_label=config["start"],
+            end_label=config["end"],
+            step=config["step"],
+            increment_letter=config["increment_letter"],
+            label_type=config["label_type"],
+        )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Floor Plan! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #167 

## What's Changed

Added two new filters for the RackFilterExtension to filter racks based on either the "X" or "Y" origin. This allows you to click on the Grid label for any row on either the "X" and "Y" axis and be redirected to the rack elevation view. The view will be filtered with racks that have the corresponding "X" or "Y" origin.

![Screenshot 2025-03-25 at 12 39 16 PM](https://github.com/user-attachments/assets/ae4e5d50-007b-4d78-b6bf-fe53f4381e75)
![Screenshot 2025-03-25 at 12 39 29 PM](https://github.com/user-attachments/assets/38da3a73-8588-468b-a122-b60fa073f271)

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
