### PR TITLE
Update indented bullets

### DIFF
--- a/changes/173.fixed
+++ b/changes/173.fixed
@@ -1,0 +1,1 @@
+Fixed bullets to render properly in mkdocs which expects 4 spaces to indent.

--- a/docs/user/app_getting_started.md
+++ b/docs/user/app_getting_started.md
@@ -84,31 +84,31 @@ The **Custom Labels** tab provides options to configure a custom label range usi
 
 - **`increment_letter`** *(optional)*
   Applicable only for *numalpha* and *alphanumeric* label types, this parameter controls whether letter patterns increment.
-  - *Default*: `true`
-  - When set to `true`:
-  - The letter portions increment,  but the numeric portions do not creating patterns like:
-    - For numalpha: `02AA, 02AB, 02AC`
-    - For alphanumeric: `A01, B01, C01`
-  - When set to `false`:
-  - For numalpha:
-    - The entire letter portion increments with every step creating patterns like:
-    - `02AA, 02BB, 02CC`
-  - For alphanumeric:
-    - The letter prefix does not increment, but the numeric portion does creating patterns like:
-    - `A01, A02, A03`
+    - *Default*: `true`
+    - When set to `true`:
+    - The letter portions increment,  but the numeric portions do not creating patterns like:
+        - For numalpha: `02AA, 02AB, 02AC`
+        - For alphanumeric: `A01, B01, C01`
+    - When set to `false`:
+    - For numalpha:
+        - The entire letter portion increments with every step creating patterns like:
+        - `02AA, 02BB, 02CC`
+    - For alphanumeric:
+        - The letter prefix does not increment, but the numeric portion does creating patterns like:
+        - `A01, A02, A03`
 
   Both *numalpha* and *alphanumeric* label types support leading or non-leading zero formats.
 
 - **`label_type`**
   Specifies the type of label. Supported types include:
-  - `numalpha (e.g., 02A, 05ZZ, 04AZ)`
-  - `alphanumeric (e.g., A01, B02)`
-  - `roman (e.g., I, II, III)`
-  - `greek (e.g., α, β, γ)`
-  - `hex (e.g., 0x0001, 0x000A, 0x000F)`
-  - `binary (e.g., 0b0001, 0b1010, 0b0110)`
-  - `letters (e.g., A, B, C)`
-  - `numbers (e.g. 1, 2, 3)`
+    - `numalpha (e.g., 02A, 05ZZ, 04AZ)`
+    - `alphanumeric (e.g., A01, B02)`
+    - `roman (e.g., I, II, III)`
+    - `greek (e.g., α, β, γ)`
+    - `hex (e.g., 0x0001, 0x000A, 0x000F)`
+    - `binary (e.g., 0b0001, 0b1010, 0b0110)`
+    - `letters (e.g., A, B, C)`
+    - `numbers (e.g. 1, 2, 3)`
 
 There is a `Generate Preview` button that allows you to preview a range of labels that would be generated on the grid once the Floor Plan form has been saved.
 
@@ -164,7 +164,7 @@ For each tile, you can:
 - **Assign a Object or RackGroup**: Specify the object or rack group associated with the tile.
 - **Specify Rack Orientation**: Define the orientation of the object relative to the floor plan.
 - **Adjust Tile Size**: Expand a tile to cover multiple spaces.
-  - Useful for documenting larger-than-usual racks or marking sections of the floor plan as "Reserved" or "Unavailable."
+    - Useful for documenting larger-than-usual racks or marking sections of the floor plan as "Reserved" or "Unavailable."
 
 !!! note
     Once a Object (Device, Power Panel, Power Feed, or Rack) has been placed on a **Floor Plan Tile** you cannot update the **Location** of the Object until it has been removed from the Floor Plan or the Floor Plan has been deleted.

--- a/docs/user/app_getting_started.md
+++ b/docs/user/app_getting_started.md
@@ -53,15 +53,15 @@ Default settings allow you to configure labels, seeds, and steps for each axis o
 
 - **X Axis Labels** and **Y Axis Labels**:
   Represent grid labels as either `"Numbers"` or `"Letters"`.
-  - Default: `"Numbers"`
+    - Default: `"Numbers"`
 
 - **X Axis Seed** and **Y Axis Seed**:
   Define the starting point for grid labels.
-  - Default: `"1"`
+    - Default: `"1"`
 
 - **X Axis Step** and **Y Axis Step**:
   Set a positive or negative integer step value to skip numbers or letters in grid labeling.
-  - Default: `"1"`
+    - Default: `"1"`
 
 ![Add Floor Plan form part 2](../images/add-tile-axis-default.png)
 


### PR DESCRIPTION
# Closes: N/A

## What's Changed


Updated bullets to render properly in mkdocs, which expects 4 spaces to indent


# Screenshots
| --            | Before                                                                                     | After                                                                                       |
|-----------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| Bullet List       |![image](https://github.com/user-attachments/assets/1e733db6-a261-4440-b685-c05f40c200fb)|![image](https://github.com/user-attachments/assets/1446576f-1006-4785-907f-77ed91c18a43)|


## To Do

N/A