### PR TITLE
fix: correct rack elevation filter for default letter-based axis labels

### DIFF
--- a/changes/211.fixed
+++ b/changes/211.fixed
@@ -1,0 +1,1 @@
+Fixed rack elevation filter incorrectly returning all racks when clicking letter-based column labels on the floor plan SVG.

--- a/nautobot_floor_plan/filter_extensions.py
+++ b/nautobot_floor_plan/filter_extensions.py
@@ -5,7 +5,8 @@ import logging
 import django_filters
 from nautobot.apps.filters import FilterExtension, RelatedMembershipBooleanFilter
 
-from nautobot_floor_plan import models
+from nautobot_floor_plan import choices, models
+from nautobot_floor_plan.utils.general import axis_clean_label_conversion
 from nautobot_floor_plan.utils.label_converters import LabelToPositionConverter, PositionToLabelConverter
 
 logger = logging.getLogger(__name__)
@@ -39,8 +40,13 @@ class FloorPlanCoordinateFilter(django_filters.CharFilter):
                 converter = LabelToPositionConverter(value, self.axis, floor_plan)
                 position, _ = converter.convert()
             else:
-                # For default labels, use the value directly
-                position = value
+                # For default labels use the existing utility which handles the inverse
+                # of the label generation formula, including negative steps and wrap-around.
+                axis_labels = getattr(floor_plan, f"{self.axis.lower()}_axis_labels")
+                seed = getattr(floor_plan, f"{self.axis.lower()}_origin_seed")
+                step = getattr(floor_plan, f"{self.axis.lower()}_axis_step")
+                is_letters = axis_labels == choices.AxisLabelsChoices.LETTERS
+                position = axis_clean_label_conversion(seed, value, step, is_letters)
 
             return super().filter(qs, position)
 

--- a/nautobot_floor_plan/tests/test_filters.py
+++ b/nautobot_floor_plan/tests/test_filters.py
@@ -346,3 +346,251 @@ class TestFloorPlanCoordinateFilter(TestCase):
 
         # Original value should be returned
         self.assertEqual(result, "1")
+
+
+class TestFloorPlanCoordinateFilterDefaultLabels(TestCase):
+    """Test FloorPlanCoordinateFilter with default (non-custom) letter and number labels.
+
+    Regression test for the bug where clicking an X-axis letter label (e.g. "A") on
+    the SVG floor plan returned ALL racks instead of only the racks in that column.
+    The filter was passing the raw letter string directly to the DB IntegerField query.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up a 5x5 floor plan with letter X-axis and numeric Y-axis, and 25 rack tiles."""
+        data = fixtures.create_prerequisites()
+        cls.active_status = data["status"]
+
+        # Floor plan with X=letters (A-E), Y=numbers (1-5)
+        cls.floor_plan = models.FloorPlan(
+            location=data["floors"][0],
+            x_size=5,
+            y_size=5,
+            x_axis_labels=choices.AxisLabelsChoices.LETTERS,
+            y_axis_labels=choices.AxisLabelsChoices.NUMBERS,
+            x_origin_seed=1,
+            y_origin_seed=1,
+        )
+        cls.floor_plan.validated_save()
+
+        # Create 25 tiles: x_origin 1-5 maps to labels A-E, y_origin 1-5 maps to labels 1-5
+        for y in range(1, 6):
+            for x in range(1, 6):
+                models.FloorPlanTile.objects.create(
+                    floor_plan=cls.floor_plan,
+                    x_origin=x,
+                    y_origin=y,
+                    status=cls.active_status,
+                )
+
+    def _make_filter(self, axis, field_name):
+        """Return a FloorPlanCoordinateFilter with its parent wired to cls.floor_plan."""
+        f = filter_extensions.FloorPlanCoordinateFilter(axis=axis, field_name=field_name)
+        f.parent = MagicMock()
+        f.parent.data = {"nautobot_floor_plan_floor_plan": self.floor_plan.pk}
+        return f
+
+    # ------------------------------------------------------------------
+    # X-axis (letter labels) – this was broken, reports in issue #211
+    # ------------------------------------------------------------------
+
+    def test_x_letter_label_returns_only_matching_column(self):
+        """Clicking column 'A' (x_origin=1) must return exactly 5 tiles, not all 25."""
+        f = self._make_filter("X", "x_origin")
+        qs = models.FloorPlanTile.objects.filter(floor_plan=self.floor_plan)
+        result = f.filter(qs, "A")
+        self.assertEqual(result.count(), 5)
+        self.assertEqual(set(result.values_list("x_origin", flat=True)), {1})
+
+    def test_x_letter_label_mid_column(self):
+        """Clicking column 'C' (x_origin=3) must return exactly the 5 tiles in that column."""
+        f = self._make_filter("X", "x_origin")
+        qs = models.FloorPlanTile.objects.filter(floor_plan=self.floor_plan)
+        result = f.filter(qs, "C")
+        self.assertEqual(result.count(), 5)
+        self.assertEqual(set(result.values_list("x_origin", flat=True)), {3})
+
+    def test_x_letter_label_last_column(self):
+        """Clicking column 'E' (x_origin=5) must return exactly 5 tiles."""
+        f = self._make_filter("X", "x_origin")
+        qs = models.FloorPlanTile.objects.filter(floor_plan=self.floor_plan)
+        result = f.filter(qs, "E")
+        self.assertEqual(result.count(), 5)
+        self.assertEqual(set(result.values_list("x_origin", flat=True)), {5})
+
+    # ------------------------------------------------------------------
+    # Y-axis (numeric labels) – was already working; verify the fix didn't break it
+    # ------------------------------------------------------------------
+
+    def test_y_numeric_label_returns_only_matching_row(self):
+        """Clicking row '1' (y_origin=1) must return exactly 5 tiles."""
+        f = self._make_filter("Y", "y_origin")
+        qs = models.FloorPlanTile.objects.filter(floor_plan=self.floor_plan)
+        result = f.filter(qs, "1")
+        self.assertEqual(result.count(), 5)
+        self.assertEqual(set(result.values_list("y_origin", flat=True)), {1})
+
+    def test_y_numeric_label_mid_row(self):
+        """Clicking row '3' (y_origin=3) must return exactly 5 tiles."""
+        f = self._make_filter("Y", "y_origin")
+        qs = models.FloorPlanTile.objects.filter(floor_plan=self.floor_plan)
+        result = f.filter(qs, "3")
+        self.assertEqual(result.count(), 5)
+        self.assertEqual(set(result.values_list("y_origin", flat=True)), {3})
+
+
+class TestFloorPlanCoordinateFilterSeedAndStep(TestCase):
+    """Test FloorPlanCoordinateFilter with non-default seed and step values.
+
+    The label generation formula is: label = seed + (position - seed) * step
+    The inverse is handled by axis_clean_label_conversion() in utils/general.py.
+
+    Each test method covers one configuration so data stays isolated.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        """Shared prerequisites for all seed/step tests."""
+        cls.data = fixtures.create_prerequisites()
+        cls.active_status = cls.data["status"]
+
+    def _make_floor_plan(self, floor_idx, x_size, y_size, **kwargs):
+        """Create and return a validated FloorPlan on the given floor index."""
+        fp = models.FloorPlan(
+            location=self.data["floors"][floor_idx],
+            x_size=x_size,
+            y_size=y_size,
+            **kwargs,
+        )
+        fp.validated_save()
+        return fp
+
+    def _make_tiles(self, floor_plan):
+        """Create one tile per grid cell for the given floor plan."""
+        for y in range(floor_plan.y_origin_seed, floor_plan.y_origin_seed + floor_plan.y_size):
+            for x in range(floor_plan.x_origin_seed, floor_plan.x_origin_seed + floor_plan.x_size):
+                models.FloorPlanTile.objects.create(
+                    floor_plan=floor_plan, x_origin=x, y_origin=y, status=self.active_status
+                )
+
+    def _make_filter(self, floor_plan, axis, field_name):
+        """Return a wired FloorPlanCoordinateFilter for the given floor plan."""
+        f = filter_extensions.FloorPlanCoordinateFilter(axis=axis, field_name=field_name)
+        f.parent = MagicMock()
+        f.parent.data = {"nautobot_floor_plan_floor_plan": floor_plan.pk}
+        return f
+
+    # ------------------------------------------------------------------
+    # Non-default seed, letter X-axis
+    # label = seed + (position - seed) * 1  →  C(3),D(4),E(5),F(6),G(7)
+    # ------------------------------------------------------------------
+
+    def test_letter_axis_non_default_seed(self):
+        """seed=3 (C), step=1: label 'E' must resolve to x_origin=5."""
+        fp = self._make_floor_plan(
+            0,
+            x_size=5,
+            y_size=3,
+            x_axis_labels=choices.AxisLabelsChoices.LETTERS,
+            y_axis_labels=choices.AxisLabelsChoices.NUMBERS,
+            x_origin_seed=3,
+            y_origin_seed=1,
+        )
+        self._make_tiles(fp)
+        f = self._make_filter(fp, "X", "x_origin")
+        qs = models.FloorPlanTile.objects.filter(floor_plan=fp)
+
+        result = f.filter(qs, "C")  # first column, x_origin=3
+        self.assertEqual(result.count(), 3)
+        self.assertEqual(set(result.values_list("x_origin", flat=True)), {3})
+
+        result = f.filter(qs, "E")  # third column, x_origin=5
+        self.assertEqual(result.count(), 3)
+        self.assertEqual(set(result.values_list("x_origin", flat=True)), {5})
+
+    # ------------------------------------------------------------------
+    # Non-default step=2, letter X-axis
+    # position 1→A(1), 2→C(3), 3→E(5), 4→G(7), 5→I(9)
+    # ------------------------------------------------------------------
+
+    def test_letter_axis_step_2(self):
+        """seed=1, step=2: label 'C' must resolve to x_origin=2, 'E' to x_origin=3."""
+        fp = self._make_floor_plan(
+            1,
+            x_size=5,
+            y_size=3,
+            x_axis_labels=choices.AxisLabelsChoices.LETTERS,
+            y_axis_labels=choices.AxisLabelsChoices.NUMBERS,
+            x_origin_seed=1,
+            y_origin_seed=1,
+            x_axis_step=2,
+        )
+        self._make_tiles(fp)
+        f = self._make_filter(fp, "X", "x_origin")
+        qs = models.FloorPlanTile.objects.filter(floor_plan=fp)
+
+        result = f.filter(qs, "C")  # step=2: C(3) → x_origin=2
+        self.assertEqual(result.count(), 3)
+        self.assertEqual(set(result.values_list("x_origin", flat=True)), {2})
+
+        result = f.filter(qs, "E")  # step=2: E(5) → x_origin=3
+        self.assertEqual(result.count(), 3)
+        self.assertEqual(set(result.values_list("x_origin", flat=True)), {3})
+
+    # ------------------------------------------------------------------
+    # Non-default seed, numeric Y-axis
+    # seed=5, step=1: positions 5,6,7,8,9 → labels 5,6,7,8,9
+    # ------------------------------------------------------------------
+
+    def test_numeric_axis_non_default_seed(self):
+        """seed=5, step=1: label '7' must resolve to y_origin=7."""
+        fp = self._make_floor_plan(
+            2,
+            x_size=3,
+            y_size=5,
+            x_axis_labels=choices.AxisLabelsChoices.NUMBERS,
+            y_axis_labels=choices.AxisLabelsChoices.NUMBERS,
+            x_origin_seed=1,
+            y_origin_seed=5,
+        )
+        self._make_tiles(fp)
+        f = self._make_filter(fp, "Y", "y_origin")
+        qs = models.FloorPlanTile.objects.filter(floor_plan=fp)
+
+        result = f.filter(qs, "5")  # first row, y_origin=5
+        self.assertEqual(result.count(), 3)
+        self.assertEqual(set(result.values_list("y_origin", flat=True)), {5})
+
+        result = f.filter(qs, "7")  # third row, y_origin=7
+        self.assertEqual(result.count(), 3)
+        self.assertEqual(set(result.values_list("y_origin", flat=True)), {7})
+
+    # ------------------------------------------------------------------
+    # Non-default step=2, numeric Y-axis
+    # position 1→1, 2→3, 3→5, 4→7, 5→9
+    # ------------------------------------------------------------------
+
+    def test_numeric_axis_step_2(self):
+        """seed=1, step=2: label '5' must resolve to y_origin=3, label '9' to y_origin=5."""
+        fp = self._make_floor_plan(
+            3,
+            x_size=3,
+            y_size=5,
+            x_axis_labels=choices.AxisLabelsChoices.NUMBERS,
+            y_axis_labels=choices.AxisLabelsChoices.NUMBERS,
+            x_origin_seed=1,
+            y_origin_seed=1,
+            y_axis_step=2,
+        )
+        self._make_tiles(fp)
+        f = self._make_filter(fp, "Y", "y_origin")
+        qs = models.FloorPlanTile.objects.filter(floor_plan=fp)
+
+        result = f.filter(qs, "5")  # step=2: label 5 → y_origin=3
+        self.assertEqual(result.count(), 3)
+        self.assertEqual(set(result.values_list("y_origin", flat=True)), {3})
+
+        result = f.filter(qs, "9")  # step=2: label 9 → y_origin=5
+        self.assertEqual(result.count(), 3)
+        self.assertEqual(set(result.values_list("y_origin", flat=True)), {5})

--- a/poetry.lock
+++ b/poetry.lock
@@ -826,34 +826,11 @@ profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
 name = "django"
-version = "4.2.29"
-description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
-optional = false
-python-versions = ">=3.8"
-groups = ["main", "dev"]
-markers = "python_version < \"3.12\""
-files = [
-    {file = "django-4.2.29-py3-none-any.whl", hash = "sha256:074d7c4d2808050e528388bda442bd491f06def4df4fe863f27066851bba010c"},
-    {file = "django-4.2.29.tar.gz", hash = "sha256:86d91bc8086569c8d08f9c55888b583a921ac1f95ed3bdc7d5659d4709542014"},
-]
-
-[package.dependencies]
-asgiref = ">=3.6.0,<4"
-sqlparse = ">=0.3.1"
-tzdata = {version = "*", markers = "sys_platform == \"win32\""}
-
-[package.extras]
-argon2 = ["argon2-cffi (>=19.1.0)"]
-bcrypt = ["bcrypt"]
-
-[[package]]
-name = "django"
 version = "5.2.12"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
-markers = "python_version >= \"3.12\""
 files = [
     {file = "django-5.2.12-py3-none-any.whl", hash = "sha256:4853482f395c3a151937f6991272540fcbf531464f254a347bf7c89f53c8cff7"},
     {file = "django-5.2.12.tar.gz", hash = "sha256:6b809af7165c73eff5ce1c87fdae75d4da6520d6667f86401ecf55b681eb1eeb"},
@@ -882,33 +859,11 @@ files = [
 
 [[package]]
 name = "django-celery-beat"
-version = "2.7.0"
-description = "Database-backed Periodic Tasks."
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-markers = "python_version < \"3.12\""
-files = [
-    {file = "django_celery_beat-2.7.0-py3-none-any.whl", hash = "sha256:851c680d8fbf608ca5fecd5836622beea89fa017bc2b3f94a5b8c648c32d84b1"},
-    {file = "django_celery_beat-2.7.0.tar.gz", hash = "sha256:8482034925e09b698c05ad61c36ed2a8dbc436724a3fe119215193a4ca6dc967"},
-]
-
-[package.dependencies]
-celery = ">=5.2.3,<6.0"
-cron-descriptor = ">=1.2.32"
-Django = ">=2.2,<5.2"
-django-timezone-field = ">=5.0"
-python-crontab = ">=2.3.4"
-tzdata = "*"
-
-[[package]]
-name = "django-celery-beat"
 version = "2.8.1"
 description = "Database-backed Periodic Tasks."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
 files = [
     {file = "django_celery_beat-2.8.1-py3-none-any.whl", hash = "sha256:da2b1c6939495c05a551717509d6e3b79444e114a027f7b77bf3727c2a39d171"},
     {file = "django_celery_beat-2.8.1.tar.gz", hash = "sha256:dfad0201c0ac50c91a34700ef8fa0a10ee098cc7f3375fe5debed79f2204f80a"},
@@ -2412,79 +2367,11 @@ mkdocstrings = ">=0.26"
 
 [[package]]
 name = "nautobot"
-version = "3.0.8"
-description = "Source of truth and network automation platform."
-optional = false
-python-versions = "<3.14,>=3.10"
-groups = ["main"]
-markers = "python_version < \"3.12\""
-files = [
-    {file = "nautobot-3.0.8-py3-none-any.whl", hash = "sha256:a01fa26417ddc5c62218667154c37ce29b12c79619efea23dd533e6abc191659"},
-    {file = "nautobot-3.0.8.tar.gz", hash = "sha256:f2869e2d733b47dd186ba8f3df3cef26cdbbb82f56081add02205e75b938cc47"},
-]
-
-[package.dependencies]
-celery = ">=5.6.2,<5.7.0"
-cryptography = ">=46.0.5,<46.1.0"
-Django = ">=4.2.28,<4.3.0"
-django-ajax-tables = ">=1.1.1,<1.2.0"
-django-celery-beat = ">=2.7.0,<2.8.0"
-django-celery-results = ">=2.6.0,<2.7.0"
-django-constance = ">=4.3.4,<4.4.0"
-django-cors-headers = ">=4.9.0,<4.10.0"
-django-db-file-storage = ">=0.5.6.1,<0.6.0.0"
-django-extensions = ">=4.1,<4.2"
-django-filter = ">=25.1,<25.2"
-django-health-check = ">=3.20.8,<3.21.0"
-django-jinja = ">=2.11.0,<2.12.0"
-django-prometheus = ">=2.4.1,<2.5.0"
-django-redis = ">=6.0.0,<6.1.0"
-django-silk = ">=5.4.3,<5.5.0"
-django-structlog = {version = ">=10.0.0,<10.1.0", extras = ["celery"]}
-django-tables2 = ">=2.8.0,<2.9.0"
-django-taggit = ">=6.1.0,<6.2.0"
-django-timezone-field = ">=7.2.1,<7.3.0"
-django-tree-queries = ">=0.23.1,<0.24.0"
-django-webserver = ">=1.2.0,<1.3.0"
-djangorestframework = ">=3.16.1,<3.17.0"
-drf-spectacular = {version = ">=0.28.0,<0.29.0", extras = ["sidecar"]}
-emoji = ">=2.15.0,<2.16.0"
-GitPython = ">=3.1.46,<3.2.0"
-graphene-django = ">=3.2.3,<3.3.0"
-graphene-django-optimizer = ">=0.10.0,<0.11.0"
-Jinja2 = ">=3.1.6,<3.2.0"
-jsonschema = ">=4.7.0,<5.0.0"
-kubernetes = ">=33.1.0,<34.0.0"
-Markdown = ">=3.8.2,<3.9.0"
-netaddr = ">=1.3.0,<1.4.0"
-netutils = ">=1.14.0,<2.0.0"
-nh3 = ">=0.3.3,<0.4.0"
-packaging = ">=23.1"
-Pillow = ">=12.1.1,<13.0.0"
-prometheus-client = ">=0.23.1,<0.24.0"
-psycopg2-binary = ">=2.9.11,<2.10.0"
-python-slugify = ">=8.0.4,<8.1.0"
-pyuwsgi = ">=2.0.30,<2.1.0"
-PyYAML = ">=6.0.3,<6.1.0"
-social-auth-app-django = ">=5.4.3,<5.5.0"
-svgwrite = ">=1.4.3,<1.5.0"
-
-[package.extras]
-all = ["django-auth-ldap (>=5.2.0,<5.3.0)", "django-storages (>=1.14.6,<1.15.0)", "mysqlclient (>=2.2.8,<2.3.0)", "napalm (>=4.1.0,<6.0.0)", "social-auth-core[saml] (>=4.8.5,<4.9.0)"]
-ldap = ["django-auth-ldap (>=5.2.0,<5.3.0)"]
-mysql = ["mysqlclient (>=2.2.8,<2.3.0)"]
-napalm = ["napalm (>=4.1.0,<6.0.0)"]
-remote-storage = ["django-storages (>=1.14.6,<1.15.0)"]
-sso = ["social-auth-core[saml] (>=4.8.5,<4.9.0)"]
-
-[[package]]
-name = "nautobot"
 version = "3.1.0a3"
 description = "Source of truth and network automation platform."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
 files = [
     {file = "nautobot-3.1.0a3-py3-none-any.whl", hash = "sha256:ab535ea7e3ac4af7014b5257d586d327adf8aae2c3f8ff4f90afe314c5659850"},
     {file = "nautobot-3.1.0a3.tar.gz", hash = "sha256:19c740cba24f3cd7646c5253feaa63785020960a9e64b528fec4818315cdd5a2"},
@@ -4244,32 +4131,11 @@ files = [
 
 [[package]]
 name = "social-auth-app-django"
-version = "5.4.3"
-description = "Python Social Authentication, Django integration."
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "python_version < \"3.12\""
-files = [
-    {file = "social_auth_app_django-5.4.3-py3-none-any.whl", hash = "sha256:db70b972faeb10ee1ec83d0dc7dbd0558d5f5830417bba317b712b10ff58d031"},
-    {file = "social_auth_app_django-5.4.3.tar.gz", hash = "sha256:d1f4286d5ca1e512c9b2f686e7ecb2a0128148f1a33d853b69dc07b58508362e"},
-]
-
-[package.dependencies]
-Django = ">=3.2"
-social-auth-core = ">=4.4,<5.0"
-
-[package.extras]
-dev = ["coverage (>=3.6)"]
-
-[[package]]
-name = "social-auth-app-django"
 version = "5.6.0"
 description = "Python Social Authentication, Django integration."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
 files = [
     {file = "social_auth_app_django-5.6.0-py3-none-any.whl", hash = "sha256:43ca88cc5cd9161710896165ced58b3155e8aafaaff847e859879194770f138d"},
     {file = "social_auth_app_django-5.6.0.tar.gz", hash = "sha256:c695501fcbf6fe87f68f5a79e379abe853662f5129e7ec6cb758a75d5b28c888"},

--- a/tasks.py
+++ b/tasks.py
@@ -968,7 +968,7 @@ def unittest(  # noqa: PLR0913
         command += f" --tag={t}"
 
     if "integration" in tags:
-        start(context, service="nautobot")
+        start(context, service=["nautobot"])
     run_command(context, command)
 
 


### PR DESCRIPTION

# Closes: #211 

## What's Changed

FloorPlanCoordinateFilter was passing the raw label value directly to the DB query causing all racks to appear when clicking a letter column label on the floor plan SVG.

Fixed the filter to use axis_clean_label_conversion() for both letter and numeric default labels, correctly reversing the label generation formula and handling non-default seeds, steps, and wrap-around.

Also fix invoke unittest task passing service as a string instead of a list, which caused Docker Compose to receive "n a u t o b o t" as separate service names.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests
